### PR TITLE
handle permission error

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -68,6 +68,9 @@ func (c *CmdArgs) Validate() error {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("%s file doesn't exist.", file)
 		}
+		if os.IsPermission(err) {
+			return fmt.Errorf("%s permission denied.", file)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
# Current behavior

slotchmod spins the slot, even though it's certain that chmod will fail.

```
vagrant@vagrant:~/ghq/github.com/jiro4989/slotchmod$ mkdir d
vagrant@vagrant:~/ghq/github.com/jiro4989/slotchmod$ touch d/f
vagrant@vagrant:~/ghq/github.com/jiro4989/slotchmod$ chmod -x d
vagrant@vagrant:~/ghq/github.com/jiro4989/slotchmod$ ./slotchmod d/f
chmod 0555 d/f
panic: chmod d/f: permission denied

goroutine 1 [running]:
main.changeMode(0xc00001c0c0, {0xc000010050, 0x1, 0x6})
	/home/vagrant/ghq/github.com/jiro4989/slotchmod/main.go:86 +0x2e5
main.main()
	/home/vagrant/ghq/github.com/jiro4989/slotchmod/main.go:42 +0x155
```

# Expected behavior

Like the case with the missing file, I think it is good to make an error first.

# Behavior after the change

minimum permission:

```
vagrant@vagrant:~/ghq/github.com/jiro4989/slotchmod$ chmod 100 d
vagrant@vagrant:~/ghq/github.com/jiro4989/slotchmod$ ./slotchmod d/f
chmod 0026 d/f
vagrant@vagrant:~/ghq/github.com/jiro4989/slotchmod$ chmod 000 d/f
vagrant@vagrant:~/ghq/github.com/jiro4989/slotchmod$ echo $?
0
```

not enough permission:

```
vagrant@vagrant:~/ghq/github.com/jiro4989/slotchmod$ chmod 600 d
vagrant@vagrant:~/ghq/github.com/jiro4989/slotchmod$ ./slotchmod d/f
[ERR] d/f permission denied.
vagrant@vagrant:~/ghq/github.com/jiro4989/slotchmod$ chmod 000 d/f
chmod: cannot access 'd/f': Permission denied
```